### PR TITLE
Modify error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,35 +105,45 @@ The validation function accepts the current value and the overall form value.
 The validation function can either return a string or undefined; the string
 return value is interpreted as an error.
 
-> ⚠ These validation functions can also be used for objects and arrays. But, it's
-> better to use it for literals to keep the inferred typings correct.
+### Validation functions
 
-There are built in validation functions for required condition, email
-condition, url condition, greater than condition, less than condition and many
-more.
+The library provides these validation function:
+
+- requiredCondition
+- requiredStringCondition
+- requiredListCondition
+- blacklistCondition
+- whitelistCondition
+- lengthGreaterThanCondition
+- lengthSmallerThanCondition
+- greaterThanCondition
+- smallerThanCondition
+- greaterThanOrEqualToCondition
+- lessThanOrEqualToCondition
+- integerCondition
+- emailCondition
+- urlCondition
 
 #### Special validation functions
 
-##### nonNullType
-
-The form sets `null` to indicate there is no information. On special cases, we
-would want to set `undefined` instead of `null`. We can use `nonNullType` to
-get that behavior.
-
-##### nullType
+##### forceNullType
 
 Sometimes we would want to clear value for certain fields. We can use
-`nullType` to conditionally clear values.
+`forceNullType` to conditionally clear values.
 
-##### ⚠ arrayType
+##### forceEmptyArrayType
 
-For array type, we should add `arrayType` so that the typings for error and the
-actual error value will match.
+Sometimes we would want to clear value for certain fields. We can use
+`forceEmptyArrayType` to conditionally clear array values.
 
-##### ⚠ nonNullArrayType
+##### defaultUndefinedType
 
-For array type, we would want to set `[]` to indicate there is no information.
-We can use `nonNullArrayType` to get that behavior.
+The form sets `null` to indicate there is no information. On special cases, we
+would want to set `undefined` instead of `null`.
+
+##### defaultEmptyArrayType
+
+For array type, we would want to set `[]` to when there is no data.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,8 +1,144 @@
 # Toggle Form
 
-React form library by Togglecorp
+A simple form library using react hooks
 
-## Get Started
+
+## Features
+
+- Powerful validation
+- Supports nested forms
+- Supports conditional fields
+- Reasonably typesafe
+
+## Introduction
+
+The library exposes three react hooks to define a form.
+
+1. useForm
+2. useArrayField
+3. useObjectField
+
+### useForm
+
+`useForm` hook is used to control a form.
+The `useForm` hook accepts these options:
+
+|option|description|
+|----|----|
+|value|The initial value for the form|
+|schema|The schema used to validate the form|
+
+The return value from `useForm` hooks are as follows:
+
+|value|description|
+|----|----|
+|value|The value of the form|
+|error|The error state of the form|
+|pristine|The pristine state of the form|
+|pristine|Defines if the form is pristine|
+|validate|If there are errors, sets form error else returns sanitized value|
+|onPristineSet|Function to set form's pristine state|
+|onErrorSet|Function to set form's error state|
+|onValueSet|Function to set form's value, error is cleared and pristine is set to true|
+|onValueChange|Function to set form field's value and pristine is set to false|
+
+### useFormObject
+
+`useFormObject` hook is used to control an object.
+The `useFormObject` hook accepts these options:
+
+|option|description|
+|----|----|
+|name|name of the object field|
+|onChange| change handler of the object|
+|defaultValue|default value for the object|
+
+The return value from `useFormObject` is the change handler for the object
+fields.
+
+### useFormArray
+
+`useFormArray` hook is used to control an array.
+The `useFormArray` hook accepts these options:
+
+|option|description|
+|----|----|
+|name|name of the array field|
+|onChange| change handler of the array|
+
+The return value from `useFormArray` are as follows:
+
+|value|description|
+|----|----|
+|onValueChange|The change handler for the array items.|
+|onValueRemove|The delete handler for the array items.|
+
+### Schema
+
+The schema defines the structure of the form.
+The schema can defined for objects, arrays and literals.
+
+### Object Schema
+
+The schema object is an object with these properties:
+
+|property|description|
+|----|----|
+|validation|Function to validate the object|
+|fields|Function that defines the schema for each key of the object|
+|fieldDependencies|Function that defines the dependency between object keys|
+
+### Array Schema
+
+The array schema is an object with these properties:
+
+|property|description|
+|----|----|
+|validation|Function to validate the array|
+|members|Function that defines the schema for each item of the array|
+|keySelector|Function that defines the unique key for each item of the array|
+
+### Literal Schema
+
+The literal schema is an array of validation functions.
+The validation function accepts the current value and the overall form value.
+The validation function can either return a string or undefined; the string
+return value is interpreted as an error.
+
+> ⚠ These validation functions can also be used for objects and arrays. But, it's
+> better to use it for literals to keep the inferred typings correct.
+
+There are built in validation functions for required condition, email
+condition, url condition, greater than condition, less than condition and many
+more.
+
+#### Special validation functions
+
+##### nonNullType
+
+The form sets `null` to indicate there is no information. On special cases, we
+would want to set `undefined` instead of `null`. We can use `nonNullType` to
+get that behavior.
+
+##### nullType
+
+Sometimes we would want to clear value for certain fields. We can use
+`nullType` to conditionally clear values.
+
+##### ⚠ arrayType
+
+For array type, we should add `arrayType` so that the typings for error and the
+actual error value will match.
+
+##### ⚠ nonNullArrayType
+
+For array type, we would want to set `[]` to indicate there is no information.
+We can use `nonNullArrayType` to get that behavior.
+
+
+## Development
+
+### Running
 
 ```bash
 # Install dependencies
@@ -12,7 +148,7 @@ yarn install
 yarn storybook
 ```
 
-## Linting
+### Linting
 
 ```bash
 # Eslint
@@ -22,23 +158,3 @@ yarn lint
 yarn typecheck
 ```
 
-## Special Cases
-
-### idCondition
-
-For all fields, the form sets `null` to indicate there is no information.
-On special cases, we would want to set `undefined` to indicate there is no information.
-We can use `idCondition` to alter that behavior.
-
-### arrayCondition
-
-For all fields, the form sets `null` to indicate there is no information.
-For array type, we would want to set `[]` to indicate there is no information.
-We can use `arrayCondition` to alter that behavior.
-
-> `arrayCondition` also alters type of error generated
-
-### nullCondition
-
-Sometimes we would want to clear value for certain fields.
-We can use `nullCondition` to conditionally clear values.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The return value from `useForm` hooks are as follows:
 |pristine|The pristine state of the form|
 |pristine|Defines if the form is pristine|
 |validate|If there are errors, sets form error else returns sanitized value|
-|onPristineSet|Function to set form's pristine state|
-|onErrorSet|Function to set form's error state|
-|onValueSet|Function to set form's value, error is cleared and pristine is set to true|
-|onValueChange|Function to set form field's value and pristine is set to false|
+|setPristine|Function to set form's pristine state|
+|setError|Function to set form's error state|
+|setValue|Function to set form's value, error is cleared and pristine is set to true|
+|setFieldValue|Function to set form field's value and pristine is set to false|
 
 ### useFormObject
 
@@ -70,8 +70,8 @@ The return value from `useFormArray` are as follows:
 
 |value|description|
 |----|----|
-|onValueChange|The change handler for the array items.|
-|onValueRemove|The delete handler for the array items.|
+|setValue|The change handler for the array items.|
+|removeValue|The delete handler for the array items.|
 
 ### Schema
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "prepack": "yarn build",
         "watch": "rollup -c -w",
         "typecheck": "tsc",
-        "lint": "eslint --rule 'import/no-unresolved: 0' 'src/**/*.[tj]s?(x)'",
+        "lint": "eslint 'src/**/*.[tj]s?(x)'",
         "storybook": "start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "chromatic": "npx chromatic --exit-zero-on-changes"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@storybook/addon-links": "^6.0.21",
         "@storybook/node-logger": "^6.0.21",
         "@storybook/react": "^6.0.21",
-        "@togglecorp/toggle-ui": "^0.9.0",
+        "@togglecorp/toggle-ui": "^0.10.1",
         "@types/node": "^14.11.2",
         "@types/react": "^16.9.49",
         "@types/react-dom": "^16.9.8",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,35 +5,11 @@ import filesize from 'rollup-plugin-filesize';
 import { eslint } from 'rollup-plugin-eslint';
 import copy from 'rollup-plugin-copy';
 
-/*
-import postcss from 'rollup-plugin-postcss';
-import stylelint from 'rollup-plugin-stylelint';
-import postcssPresetEnv from 'postcss-preset-env';
-import postcssNested from 'postcss-nested';
-import postcssNormalize from 'postcss-normalize';
-*/
-
 import pkg from './package.json';
 
 const INPUT_FILE_PATH = 'src/index.ts';
 
 const PLUGINS = [
-    /*
-    stylelint(),
-    postcss({
-        extract: true,
-        modules: {
-            localsConvention: 'camelCaseOnly',
-        },
-        autoModules: false,
-        plugins: [
-            // autoprefixer,
-            postcssPresetEnv,
-            postcssNested,
-            postcssNormalize,
-        ],
-    }),
-    */
     eslint({
         throwOnError: true,
         include: ['**/*.jsx', '**/*.js', '**/*.ts', '**/*.tsx'],

--- a/src/form.ts
+++ b/src/form.ts
@@ -13,13 +13,13 @@ import {
 
 import type { Schema, Error } from './schema';
 import type {
-    StateArg,
+    SetValueArg,
     EntriesAsKeyValue,
     EntriesAsList,
 } from './types';
 import { isCallable } from './utils';
 
-type ValidateReturn<T> = () => (
+type ValidateFunc<T> = () => (
     { errored: true, error: Error<T>, value: undefined }
     | { errored: false, value: T, error: undefined }
 )
@@ -34,16 +34,26 @@ function useForm<T extends object>(
     value: T,
     error: Error<T> | undefined,
     pristine: boolean,
-    validate: ValidateReturn<T>,
+    validate: ValidateFunc<T>,
 
     setPristine: (pristine: boolean) => void,
     setError: (errors: Error<T> | undefined) => void,
-    setValue: (value: StateArg<T>, doNotReset?: boolean) => void,
+    setValue: (value: SetValueArg<T>, doNotReset?: boolean) => void,
     setFieldValue: (...entries: EntriesAsList<T>) => void,
 } {
-    type ErrorAction = { type: 'SET_ERROR', error: Error<T> | undefined };
-    type ValueAction = { type: 'SET_VALUE', value: T | ((oldVal: T) => T), doNotReset: boolean | undefined };
-    type PristineAction = { type: 'SET_PRISTINE', value: boolean };
+    interface ErrorAction {
+        type: 'SET_ERROR';
+        error: Error<T> | undefined;
+    }
+    interface ValueAction {
+        type: 'SET_VALUE';
+        value: T | ((oldVal: T) => T);
+        doNotReset: boolean | undefined;
+    }
+    interface PristineAction {
+        type: 'SET_PRISTINE';
+        value: boolean;
+    }
     type ValueFieldAction = EntriesAsKeyValue<T> & { type: 'SET_VALUE_FIELD' };
 
     const formReducer = useCallback(
@@ -51,6 +61,20 @@ function useForm<T extends object>(
             prevState: { value: T, error: Error<T> | undefined, pristine: boolean },
             action: ValueFieldAction | ErrorAction | ValueAction | PristineAction,
         ) => {
+            if (action.type === 'SET_PRISTINE') {
+                const { value } = action;
+                return {
+                    ...prevState,
+                    pristine: value,
+                };
+            }
+            if (action.type === 'SET_ERROR') {
+                const { error } = action;
+                return {
+                    ...prevState,
+                    error,
+                };
+            }
             if (action.type === 'SET_VALUE') {
                 const {
                     value: valueFromAction,
@@ -72,20 +96,6 @@ function useForm<T extends object>(
                     value: newVal,
                     error: undefined,
                     pristine: true,
-                };
-            }
-            if (action.type === 'SET_PRISTINE') {
-                const { value } = action;
-                return {
-                    ...prevState,
-                    pristine: value,
-                };
-            }
-            if (action.type === 'SET_ERROR') {
-                const { error } = action;
-                return {
-                    ...prevState,
-                    error,
                 };
             }
             if (action.type === 'SET_VALUE_FIELD') {
@@ -157,7 +167,7 @@ function useForm<T extends object>(
     );
 
     const setValue = useCallback(
-        (value: StateArg<T>, doNotReset) => {
+        (value: SetValueArg<T>, doNotReset) => {
             const action: ValueAction = {
                 type: 'SET_VALUE',
                 value,
@@ -170,18 +180,19 @@ function useForm<T extends object>(
 
     const setFieldValue = useCallback(
         (...entries: EntriesAsList<T>) => {
+            const [value, key] = entries;
             const action: ValueFieldAction = {
                 type: 'SET_VALUE_FIELD',
-                key: entries[1],
-                value: entries[0],
+                key,
+                value,
             };
             dispatch(action);
         },
         [],
     );
 
-    const validate = useCallback(
-        (): ReturnType<ValidateReturn<T>> => {
+    const validate: ValidateFunc<T> = useCallback(
+        () => {
             const stateErrors = accumulateErrors(state.value, schema);
             const stateErrored = analyzeErrors(stateErrors);
             if (stateErrored) {
@@ -214,14 +225,14 @@ function useForm<T extends object>(
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function useFormObject<K extends string | number, T extends object | undefined>(
     name: K,
-    onChange: (value: StateArg<T>, name: K) => void,
+    onChange: (value: SetValueArg<T>, name: K) => void,
+    // TODO: maybe make defaultValue callable
     defaultValue: NonNullable<T>,
 ) {
     const setFieldValue = useCallback(
         (...entries: EntriesAsList<NonNullable<T>>) => {
             // NOTE: may need to cast callableValue here
-            const callableValue = entries[0];
-            const key = entries[1];
+            const [callableValue, key] = entries;
             onChange(
                 (oldValue: T): T => {
                     const baseValue = oldValue ?? defaultValue;
@@ -245,12 +256,12 @@ export function useFormObject<K extends string | number, T extends object | unde
 export function useFormArray<K extends string, T extends object>(
     name: K,
     onChange: (
-        newValue: StateArg<T[] | undefined>,
+        newValue: SetValueArg<T[] | undefined>,
         inputName: K,
     ) => void,
 ) {
     const setValue = useCallback(
-        (val: StateArg<T>, index: number) => {
+        (val: SetValueArg<T>, index: number) => {
             onChange(
                 (oldValue: T[] | undefined): T[] | undefined => {
                     if (!oldValue) {
@@ -288,6 +299,7 @@ export function useFormArray<K extends string, T extends object>(
     return { setValue, removeValue };
 }
 
+// FIXME: move this to helper
 export function createSubmitHandler<T>(
     validator: () => ({ errored: boolean, error: Error<T> | undefined, value: T | undefined }),
     setError: (errors: Error<T> | undefined) => void,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,5 +38,5 @@ export type {
     PurgeNull,
     EntriesAsList,
     EntriesAsKeyValue,
-    StateArg,
+    SetValueArg,
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export {
     isLocalUrl,
     isValidUrl,
     isCallable,
+    getErrorObject,
+    getErrorString,
 } from './utils';
 export * from './validation';
 
@@ -30,6 +32,7 @@ export type {
     ArrayError,
     ObjectError,
 } from './schema';
+export { internal } from './types';
 export type {
     PartialForm,
     PurgeNull,

--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -68,4 +68,5 @@ export function accumulateDifferentialErrors<T>(
 
 export function analyzeErrors<T>(errors: ArrayError<T> | ObjectError<T> | LeafError): boolean;
 
+// FIXME: mvoe to another helper
 export function removeNull<T>(data: T | undefined | null): PurgeNull<T>;

--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -1,4 +1,4 @@
-import { PurgeNull } from './types';
+import { PurgeNull, internal } from './types';
 
 export type Schema<T, V=T> = (
     Exclude<T, undefined> extends unknown[]
@@ -27,11 +27,11 @@ export type ObjectSchema<T, V=T> = {
 
 export type Error<T> = (
     Exclude<T, undefined> extends unknown[]
-        ? ArrayError<Exclude<T, undefined>[number]>
+        ? ArrayError<Exclude<T, undefined>[number]> | LeafError
         : (
             // eslint-disable-next-line @typescript-eslint/ban-types
             Exclude<T, undefined> extends object
-                ? ObjectError<Exclude<T, undefined>>
+                ? ObjectError<Exclude<T, undefined>> | LeafError
                 : LeafError
         )
 );
@@ -39,18 +39,12 @@ export type Error<T> = (
 export type LeafError = string | undefined;
 
 export type ArrayError<T> = {
-    $internal?: string;
-    members?: {
-        [key: string]: Error<T> | undefined;
-    }
-};
+    [key: string]: Error<T> | undefined;
+} & { [internal]?: string };
 
 export type ObjectError<T> = {
-    $internal?: string;
-    fields?: {
-        [K in keyof T]?: Error<T[K]> | undefined;
-    }
-};
+    [K in keyof T]?: Error<T[K]> | undefined;
+} & { [internal]?: string }
 
 export function accumulateValues<T>(
     obj: T,

--- a/src/stories/ConditionalForm.stories.tsx
+++ b/src/stories/ConditionalForm.stories.tsx
@@ -8,9 +8,11 @@ import {
 
 import useForm, { createSubmitHandler } from '../form';
 import type { PartialForm } from '../types';
+import { internal } from '../types';
 import type { ObjectSchema } from '../schema';
 import FormContainer from './FormContainer';
-import { requiredStringCondition, requiredCondition, nullCondition } from '../validation';
+import { getErrorObject } from '../utils';
+import { requiredStringCondition, requiredCondition, forceNullType } from '../validation';
 
 type FormType = {
     firstName: string;
@@ -30,9 +32,9 @@ const schema: FormSchema = {
             firstName: [requiredStringCondition],
             lastName: [],
             detailed: [],
-            job: [nullCondition],
-            age: [nullCondition],
-            address: [nullCondition],
+            job: [forceNullType],
+            age: [forceNullType],
+            address: [forceNullType],
         };
         if (value?.detailed) {
             baseSchema = {
@@ -52,7 +54,7 @@ export const Default = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -65,34 +67,36 @@ export const Default = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 <TextInput
                     label="First Name *"
                     name="firstName"
                     value={value.firstName}
                     onChange={onValueChange}
-                    error={error?.fields?.firstName}
+                    error={error?.firstName}
                 />
                 <TextInput
                     label="Last Name"
                     name="lastName"
                     value={value.lastName}
                     onChange={onValueChange}
-                    error={error?.fields?.lastName}
+                    error={error?.lastName}
                 />
                 <Checkbox
                     label="I can add more details"
                     name="detailed"
                     value={value.detailed}
                     onChange={onValueChange}
-                    // error={error?.fields?.detailed}
+                    // error={error?.detailed}
                 />
                 {value.detailed && (
                     <>
@@ -101,21 +105,21 @@ export const Default = () => {
                             name="address"
                             value={value.address}
                             onChange={onValueChange}
-                            error={error?.fields?.address}
+                            error={error?.address}
                         />
                         <NumberInput
                             label="Age *"
                             name="age"
                             value={value.age}
                             onChange={onValueChange}
-                            error={error?.fields?.age}
+                            error={error?.age}
                         />
                         <TextInput
                             label="Job"
                             name="job"
                             value={value.job}
                             onChange={onValueChange}
-                            error={error?.fields?.job}
+                            error={error?.job}
                         />
                     </>
                 )}

--- a/src/stories/ConditionalForm.stories.tsx
+++ b/src/stories/ConditionalForm.stories.tsx
@@ -55,16 +55,16 @@ export const Default = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schema, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -72,7 +72,7 @@ export const Default = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -81,21 +81,21 @@ export const Default = () => {
                     label="First Name *"
                     name="firstName"
                     value={value.firstName}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.firstName}
                 />
                 <TextInput
                     label="Last Name"
                     name="lastName"
                     value={value.lastName}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.lastName}
                 />
                 <Checkbox
                     label="I can add more details"
                     name="detailed"
                     value={value.detailed}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     // error={error?.detailed}
                 />
                 {value.detailed && (
@@ -104,21 +104,21 @@ export const Default = () => {
                             label="Address *"
                             name="address"
                             value={value.address}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.address}
                         />
                         <NumberInput
                             label="Age *"
                             name="age"
                             value={value.age}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.age}
                         />
                         <TextInput
                             label="Job"
                             name="job"
                             value={value.job}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.job}
                         />
                     </>

--- a/src/stories/FormWithDependentFields.stories.tsx
+++ b/src/stories/FormWithDependentFields.stories.tsx
@@ -8,8 +8,10 @@ import {
 
 import useForm, { createSubmitHandler } from '../form';
 import type { ObjectSchema } from '../schema';
+import { internal } from '../types';
 import type { PartialForm } from '../types';
 import FormContainer from './FormContainer';
+import { getErrorObject } from '../utils';
 
 type FormType = {
     firstName: string;
@@ -52,7 +54,7 @@ export const Default = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -65,41 +67,43 @@ export const Default = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 <TextInput
                     label="First name"
                     name="firstName"
                     value={value.firstName}
                     onChange={onValueChange}
-                    error={error?.fields?.firstName}
+                    error={error?.firstName}
                 />
                 <TextInput
                     label="Last name"
                     name="lastName"
                     value={value.lastName}
                     onChange={onValueChange}
-                    error={error?.fields?.lastName}
+                    error={error?.lastName}
                 />
                 <DateInput
                     label="Birth date"
                     name="birthDate"
                     value={value.birthDate}
                     onChange={onValueChange}
-                    error={error?.fields?.birthDate}
+                    error={error?.birthDate}
                 />
                 <TextInput
                     label="Birth place"
                     name="birthPlace"
                     value={value.birthPlace}
                     onChange={onValueChange}
-                    error={error?.fields?.birthPlace}
+                    error={error?.birthPlace}
                 />
                 <Button
                     type="submit"

--- a/src/stories/FormWithDependentFields.stories.tsx
+++ b/src/stories/FormWithDependentFields.stories.tsx
@@ -57,15 +57,9 @@ export const Default = () => {
         error: riskyError,
         setFieldValue,
         validate,
-<<<<<<< HEAD
-        onErrorSet,
-        onValueSet,
-    } = useForm(schema, defaultFormValues);
-=======
         setError,
         setValue,
-    } = useForm(defaultFormValues, schema);
->>>>>>> b84e1a7 (Rename handler names)
+    } = useForm(schema, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {

--- a/src/stories/FormWithDependentFields.stories.tsx
+++ b/src/stories/FormWithDependentFields.stories.tsx
@@ -55,16 +55,22 @@ export const Default = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
+<<<<<<< HEAD
         onErrorSet,
         onValueSet,
     } = useForm(schema, defaultFormValues);
+=======
+        setError,
+        setValue,
+    } = useForm(defaultFormValues, schema);
+>>>>>>> b84e1a7 (Rename handler names)
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -72,7 +78,7 @@ export const Default = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -81,28 +87,28 @@ export const Default = () => {
                     label="First name"
                     name="firstName"
                     value={value.firstName}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.firstName}
                 />
                 <TextInput
                     label="Last name"
                     name="lastName"
                     value={value.lastName}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.lastName}
                 />
                 <DateInput
                     label="Birth date"
                     name="birthDate"
                     value={value.birthDate}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.birthDate}
                 />
                 <TextInput
                     label="Birth place"
                     name="birthPlace"
                     value={value.birthPlace}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.birthPlace}
                 />
                 <Button

--- a/src/stories/NestedForm.stories.tsx
+++ b/src/stories/NestedForm.stories.tsx
@@ -175,16 +175,16 @@ export const Default = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schema, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -193,9 +193,9 @@ export const Default = () => {
     type Collections = typeof value.collections;
 
     const {
-        onValueChange: onCollectionChange,
-        onValueRemove: onCollectionRemove,
-    } = useFormArray('collections', onValueChange);
+        setValue: onCollectionChange,
+        removeValue: onCollectionRemove,
+    } = useFormArray('collections', setFieldValue);
 
     const handleCollectionAdd = useCallback(
         () => {
@@ -203,20 +203,20 @@ export const Default = () => {
             const newCollection: PartialForm<CollectionType> = {
                 clientId,
             };
-            onValueChange(
+            setFieldValue(
                 (oldValue: PartialForm<Collections>) => (
                     [...(oldValue ?? []), newCollection]
                 ),
                 'collections' as const,
             );
         },
-        [onValueChange],
+        [setFieldValue],
     );
 
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -225,13 +225,13 @@ export const Default = () => {
                     label="Name *"
                     name="name"
                     value={value.name}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.name}
                 />
                 <MetaInput
                     name="meta"
                     value={value.meta}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.meta}
                 />
                 <Row>

--- a/src/stories/NestedForm.stories.tsx
+++ b/src/stories/NestedForm.stories.tsx
@@ -8,7 +8,7 @@ import {
 import { randomString } from '@togglecorp/fujs';
 
 import useForm, { createSubmitHandler, useFormArray, useFormObject } from '../form';
-import type { PartialForm as RawPartialForm, StateArg } from '../types';
+import type { PartialForm as RawPartialForm, SetValueArg } from '../types';
 import type { Error, ObjectSchema, ArraySchema } from '../schema';
 import FormContainer, { Row } from './FormContainer';
 import {
@@ -19,7 +19,7 @@ import {
 import { getErrorObject } from '../utils';
 import { internal } from '../types';
 
-type PartialForm<T> = RawPartialForm<T, { clientId: string }>;
+type PartialForm<T> = RawPartialForm<T, 'clientId'>;
 
 type FormType = {
     name?: string;
@@ -73,7 +73,7 @@ interface MetaInputProps<K extends string | number> {
    name: K,
    value: MetaInputValue,
    error: Error<MetaType> | undefined;
-   onChange: (value: StateArg<MetaInputValue> | undefined, name: K) => void;
+   onChange: (value: SetValueArg<MetaInputValue> | undefined, name: K) => void;
 }
 const defaultMetaValue: NonNullable<MetaInputValue> = {};
 function MetaInput<K extends string | number>(props: MetaInputProps<K>) {
@@ -117,7 +117,7 @@ const defaultCollectionValue: PartialForm<CollectionType> = {
 interface CollectionInputProps {
    value: PartialForm<CollectionType>,
    error: Error<CollectionType> | undefined;
-   onChange: (value: StateArg<PartialForm<CollectionType>>, index: number) => void;
+   onChange: (value: SetValueArg<PartialForm<CollectionType>>, index: number) => void;
    onRemove: (index: number) => void;
    index: number,
 }

--- a/src/stories/SimpleForm.stories.tsx
+++ b/src/stories/SimpleForm.stories.tsx
@@ -3,18 +3,38 @@ import {
     Button,
     TextInput,
     PasswordInput,
+    MultiSelectInput,
 } from '@togglecorp/toggle-ui';
 
 import useForm, { createSubmitHandler } from '../form';
 import type { PartialForm } from '../types';
+import { internal } from '../types';
 import type { ObjectSchema } from '../schema';
 import FormContainer from './FormContainer';
-import { requiredStringCondition } from '../validation';
+import {
+    requiredStringCondition,
+    requiredListCondition,
+} from '../validation';
+import { getErrorObject, getErrorString } from '../utils';
+
+interface Option {
+    key: string;
+    label: string;
+}
+
+const options: Option[] = [
+    { key: '1', label: 'Music' },
+    { key: '2', label: 'Dance' },
+    { key: '3', label: 'Gardening' },
+    { key: '4', label: 'Pottery' },
+    { key: '5', label: 'Painting' },
+];
 
 type FormType = {
     username?: string;
     password?: string;
     confirmPassword?: string;
+    interests?: string[];
 };
 type FormSchema = ObjectSchema<PartialForm<FormType>>
 type FormSchemaFields = ReturnType<FormSchema['fields']>;
@@ -23,6 +43,7 @@ const schema: FormSchema = {
     fields: (): FormSchemaFields => ({
         username: [],
         password: [],
+        interests: [],
     }),
 };
 
@@ -30,6 +51,7 @@ const schemaWithValidation: FormSchema = {
     fields: (): FormSchemaFields => ({
         username: [requiredStringCondition],
         password: [requiredStringCondition],
+        interests: [requiredListCondition],
     }),
 };
 
@@ -38,6 +60,7 @@ const schemaWithCustomValidation: FormSchema = {
         username: [requiredStringCondition],
         password: [requiredStringCondition],
         confirmPassword: [requiredStringCondition],
+        interests: [requiredListCondition],
     }),
     validation: (value) => {
         if (
@@ -58,7 +81,7 @@ export const Default = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -71,27 +94,39 @@ export const Default = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 <TextInput
                     label="Username"
                     name="username"
                     value={value.username}
                     onChange={onValueChange}
-                    error={error?.fields?.username}
+                    error={error?.username}
+                />
+                <MultiSelectInput
+                    label="Interests"
+                    name="interests"
+                    options={options}
+                    value={value.interests}
+                    onChange={onValueChange}
+                    keySelector={(d) => d.key}
+                    labelSelector={(d) => d.label}
+                    error={getErrorString(error?.interests)}
                 />
                 <PasswordInput
                     label="Password"
                     name="password"
                     value={value.password}
                     onChange={onValueChange}
-                    error={error?.fields?.password}
+                    error={error?.password}
                 />
                 <Button
                     type="submit"
@@ -110,7 +145,7 @@ export const WithValidation = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -123,27 +158,39 @@ export const WithValidation = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 <TextInput
                     label="Username *"
                     name="username"
                     value={value.username}
                     onChange={onValueChange}
-                    error={error?.fields?.username}
+                    error={error?.username}
+                />
+                <MultiSelectInput
+                    label="Interests"
+                    name="interests"
+                    options={options}
+                    value={value.interests}
+                    onChange={onValueChange}
+                    keySelector={(d) => d.key}
+                    labelSelector={(d) => d.label}
+                    error={getErrorString(error?.interests)}
                 />
                 <PasswordInput
                     label="Password *"
                     name="password"
                     value={value.password}
                     onChange={onValueChange}
-                    error={error?.fields?.password}
+                    error={error?.password}
                 />
                 <Button
                     type="submit"
@@ -162,7 +209,7 @@ export const WithCustomValidation = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -175,34 +222,46 @@ export const WithCustomValidation = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 <TextInput
                     label="Username *"
                     name="username"
                     value={value.username}
                     onChange={onValueChange}
-                    error={error?.fields?.username}
+                    error={error?.username}
+                />
+                <MultiSelectInput
+                    label="Interests"
+                    name="interests"
+                    options={options}
+                    value={value.interests}
+                    onChange={onValueChange}
+                    keySelector={(d) => d.key}
+                    labelSelector={(d) => d.label}
+                    error={getErrorString(error?.interests)}
                 />
                 <PasswordInput
                     label="Password *"
                     name="password"
                     value={value.password}
                     onChange={onValueChange}
-                    error={error?.fields?.password}
+                    error={error?.password}
                 />
                 <PasswordInput
                     label="Confirm Password *"
                     name="confirmPassword"
                     value={value.confirmPassword}
                     onChange={onValueChange}
-                    error={error?.fields?.confirmPassword}
+                    error={error?.confirmPassword}
                 />
                 <Button
                     type="submit"

--- a/src/stories/SimpleForm.stories.tsx
+++ b/src/stories/SimpleForm.stories.tsx
@@ -82,16 +82,16 @@ export const Default = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schema, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -99,7 +99,7 @@ export const Default = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -108,7 +108,7 @@ export const Default = () => {
                     label="Username"
                     name="username"
                     value={value.username}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.username}
                 />
                 <MultiSelectInput
@@ -116,7 +116,7 @@ export const Default = () => {
                     name="interests"
                     options={options}
                     value={value.interests}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     keySelector={(d) => d.key}
                     labelSelector={(d) => d.label}
                     error={getErrorString(error?.interests)}
@@ -125,7 +125,7 @@ export const Default = () => {
                     label="Password"
                     name="password"
                     value={value.password}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.password}
                 />
                 <Button
@@ -146,16 +146,16 @@ export const WithValidation = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schemaWithValidation, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -163,7 +163,7 @@ export const WithValidation = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -172,7 +172,7 @@ export const WithValidation = () => {
                     label="Username *"
                     name="username"
                     value={value.username}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.username}
                 />
                 <MultiSelectInput
@@ -180,7 +180,7 @@ export const WithValidation = () => {
                     name="interests"
                     options={options}
                     value={value.interests}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     keySelector={(d) => d.key}
                     labelSelector={(d) => d.label}
                     error={getErrorString(error?.interests)}
@@ -189,7 +189,7 @@ export const WithValidation = () => {
                     label="Password *"
                     name="password"
                     value={value.password}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.password}
                 />
                 <Button
@@ -210,16 +210,16 @@ export const WithCustomValidation = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schemaWithCustomValidation, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
-            onValueSet(finalValues);
-        }, [onValueSet],
+            setValue(finalValues);
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -227,7 +227,7 @@ export const WithCustomValidation = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -236,7 +236,7 @@ export const WithCustomValidation = () => {
                     label="Username *"
                     name="username"
                     value={value.username}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.username}
                 />
                 <MultiSelectInput
@@ -244,7 +244,7 @@ export const WithCustomValidation = () => {
                     name="interests"
                     options={options}
                     value={value.interests}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     keySelector={(d) => d.key}
                     labelSelector={(d) => d.label}
                     error={getErrorString(error?.interests)}
@@ -253,14 +253,14 @@ export const WithCustomValidation = () => {
                     label="Password *"
                     name="password"
                     value={value.password}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.password}
                 />
                 <PasswordInput
                     label="Confirm Password *"
                     name="confirmPassword"
                     value={value.confirmPassword}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     error={error?.confirmPassword}
                 />
                 <Button

--- a/src/stories/StepwiseForm.stories.tsx
+++ b/src/stories/StepwiseForm.stories.tsx
@@ -7,9 +7,11 @@ import {
 
 import useForm, { createSubmitHandler } from '../form';
 import type { PartialForm } from '../types';
+import { internal } from '../types';
 import type { ObjectSchema } from '../schema';
 import FormContainer from './FormContainer';
-import { requiredStringCondition, requiredCondition, nullCondition } from '../validation';
+import { getErrorObject } from '../utils';
+import { requiredStringCondition, requiredCondition, forceNullType } from '../validation';
 
 type FormType = {
     step: number;
@@ -29,11 +31,11 @@ const schema: FormSchema = {
     fields: (value): FormSchemaFields => {
         let baseSchema: FormSchemaFields = {
             step: [],
-            firstName: [nullCondition],
-            lastName: [nullCondition],
-            job: [nullCondition],
-            age: [nullCondition],
-            address: [nullCondition],
+            firstName: [forceNullType],
+            lastName: [forceNullType],
+            job: [forceNullType],
+            age: [forceNullType],
+            address: [forceNullType],
         };
         if (value?.step === 1) {
             baseSchema = {
@@ -62,7 +64,7 @@ export const Default = () => {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         onValueChange,
         validate,
         onErrorSet,
@@ -79,13 +81,15 @@ export const Default = () => {
         }, [onValueSet],
     );
 
+    const error = getErrorObject(riskyError);
+
     return (
         <FormContainer value={value}>
             <form
                 onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
             >
                 <p>
-                    {error?.$internal}
+                    {error?.[internal]}
                 </p>
                 {value.step === 1 && (
                     <>
@@ -94,14 +98,14 @@ export const Default = () => {
                             name="firstName"
                             value={value.firstName}
                             onChange={onValueChange}
-                            error={error?.fields?.firstName}
+                            error={error?.firstName}
                         />
                         <TextInput
                             label="Last Name"
                             name="lastName"
                             value={value.lastName}
                             onChange={onValueChange}
-                            error={error?.fields?.lastName}
+                            error={error?.lastName}
                         />
                     </>
                 )}
@@ -112,21 +116,21 @@ export const Default = () => {
                             name="address"
                             value={value.address}
                             onChange={onValueChange}
-                            error={error?.fields?.address}
+                            error={error?.address}
                         />
                         <NumberInput
                             label="Age *"
                             name="age"
                             value={value.age}
                             onChange={onValueChange}
-                            error={error?.fields?.age}
+                            error={error?.age}
                         />
                         <TextInput
                             label="Job"
                             name="job"
                             value={value.job}
                             onChange={onValueChange}
-                            error={error?.fields?.job}
+                            error={error?.job}
                         />
                     </>
                 )}

--- a/src/stories/StepwiseForm.stories.tsx
+++ b/src/stories/StepwiseForm.stories.tsx
@@ -65,20 +65,20 @@ export const Default = () => {
         pristine,
         value,
         error: riskyError,
-        onValueChange,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
+        setError,
+        setValue,
     } = useForm(schema, defaultFormValues);
 
     const handleSubmit = useCallback(
         (finalValues: PartialForm<FormType>) => {
             if (finalValues.step === 1) {
-                onValueSet((val) => ({ ...val, step: 2 }));
+                setValue((val) => ({ ...val, step: 2 }));
             } else {
-                onValueSet(finalValues);
+                setValue(finalValues);
             }
-        }, [onValueSet],
+        }, [setValue],
     );
 
     const error = getErrorObject(riskyError);
@@ -86,7 +86,7 @@ export const Default = () => {
     return (
         <FormContainer value={value}>
             <form
-                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+                onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
             >
                 <p>
                     {error?.[internal]}
@@ -97,14 +97,14 @@ export const Default = () => {
                             label="First Name *"
                             name="firstName"
                             value={value.firstName}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.firstName}
                         />
                         <TextInput
                             label="Last Name"
                             name="lastName"
                             value={value.lastName}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.lastName}
                         />
                     </>
@@ -115,21 +115,21 @@ export const Default = () => {
                             label="Address *"
                             name="address"
                             value={value.address}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.address}
                         />
                         <NumberInput
                             label="Age *"
                             name="age"
                             value={value.age}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.age}
                         />
                         <TextInput
                             label="Job"
                             name="job"
                             value={value.job}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             error={error?.job}
                         />
                     </>

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,19 +1,22 @@
 export const internal = Symbol('Internal Error');
 
+type Intersects<A, B> = A extends B ? true : never;
+
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type PartialForm<T, J extends object = { uuid: string }> = T extends object ? (
+export type PartialForm<T, J extends string = 'uuid'> = T extends object ? (
     T extends (infer K)[] ? (
         PartialForm<K, J>[]
     ) : (
-        T extends J ? (
-            { [P in Exclude<keyof T, keyof J>]?: PartialForm<T[P], J> }
-            & Pick<T, keyof J>
+        Intersects<J, keyof T> extends true ? (
+            { [P in Exclude<keyof T, J>]?: PartialForm<T[P], J> }
+            & Pick<T, keyof T & J>
         ) : (
             { [P in keyof T]?: PartialForm<T[P], J> }
         )
     )
 ) : T;
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type PurgeNull<T> = (
     T extends (infer Z)[]
         ? PurgeNull<Z>[]
@@ -25,12 +28,12 @@ export type PurgeNull<T> = (
         )
 )
 
-export type StateArg<T> = T | ((value: T) => T);
+export type SetValueArg<T> = T | ((value: T) => T);
 
 export type EntriesAsList<T> = {
-    [K in keyof T]-?: [StateArg<T[K]>, K, ...unknown[]];
+    [K in keyof T]-?: [SetValueArg<T[K]>, K, ...unknown[]];
 }[keyof T];
 
 export type EntriesAsKeyValue<T> = {
-    [K in keyof T]: {key: K, value: StateArg<T[K]> };
+    [K in keyof T]: {key: K, value: SetValueArg<T[K]> };
 }[keyof T];

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,3 +1,5 @@
+export const internal = Symbol('Internal Error');
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type PartialForm<T, J extends object = { uuid: string }> = T extends object ? (
     T extends (infer K)[] ? (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,10 @@
 import { isValidUrl as isValidRemoteUrl, isNotDefined } from '@togglecorp/fujs';
-import { StateArg, internal } from './types';
+import { SetValueArg, internal } from './types';
 import type { ObjectError, ArrayError } from './schema';
 
 const localhostRegex = /(?<=\/\/)localhost(?=[:/]|$)/;
 
+// FIXME: move this to another helper
 export function getErrorObject<T>(
     value: ObjectError<T> | string | undefined,
 ): ObjectError<T> | undefined
@@ -24,6 +25,7 @@ export function getErrorObject<T>(
     return value;
 }
 
+// FIXME: move this to another helper
 export function getErrorString<T>(
     value: ArrayError<T> | ObjectError<T> | string | undefined,
 ) {
@@ -48,6 +50,6 @@ export function isValidUrl(url: string | undefined): url is string {
     return isValidRemoteUrl(sanitizedUrl);
 }
 
-export function isCallable<T>(value: StateArg<T>): value is (oldVal: T) => T {
+export function isCallable<T>(value: SetValueArg<T>): value is (oldVal: T) => T {
     return typeof value === 'function';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,40 @@
-import { isValidUrl as isValidRemoteUrl } from '@togglecorp/fujs';
-import { StateArg } from './types';
+import { isValidUrl as isValidRemoteUrl, isNotDefined } from '@togglecorp/fujs';
+import { StateArg, internal } from './types';
+import type { ObjectError, ArrayError } from './schema';
 
 const localhostRegex = /(?<=\/\/)localhost(?=[:/]|$)/;
+
+export function getErrorObject<T>(
+    value: ObjectError<T> | string | undefined,
+): ObjectError<T> | undefined
+export function getErrorObject<T>(
+    value: ArrayError<T> | string | undefined,
+): ArrayError<T> | undefined
+export function getErrorObject<T>(
+    value: ArrayError<T> | ObjectError<T> | string | undefined,
+) {
+    if (isNotDefined(value)) {
+        return undefined;
+    }
+    if (typeof value === 'string') {
+        return {
+            [internal]: value,
+        };
+    }
+    return value;
+}
+
+export function getErrorString<T>(
+    value: ArrayError<T> | ObjectError<T> | string | undefined,
+) {
+    if (isNotDefined(value)) {
+        return undefined;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    return value[internal];
+}
 
 export function isLocalUrl(url: string) {
     return localhostRegex.test(url);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -110,20 +110,18 @@ export function urlCondition(value: Maybe<string>) {
         : undefined;
 }
 
-// NOTE: this is a special condition function,
-// it defines that the field should be null
-export function nullCondition() {
+export function forceNullType() {
+    return undefined;
+}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+export function forceEmptyArrayType(_: Maybe<any[]>) {
     return undefined;
 }
 
-// NOTE: this is a special condition function,
-// it defines that the field is non-nullable
-export function idCondition() {
+export function defaultUndefinedType() {
     return undefined;
 }
-
-// NOTE: this is a special condition function,
-// it defines that the field should be [] when it is not defined
-export function arrayCondition() {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+export function defaultEmptyArrayType(_: Maybe<any[]>) {
     return undefined;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,12 +1,15 @@
 import { isValidEmail, isInteger } from '@togglecorp/fujs';
 import { isValidUrl } from './utils';
 
+// FIXME: move this to types
 type Maybe<T> = T | undefined | null;
 
+// FIXME: move this to utils
 function isDefined<T>(value: Maybe<T>): value is T {
     return value !== undefined && value !== null;
 }
 
+// FIXME: move this to utils
 function isDefinedString(value: Maybe<string>): value is string {
     return isDefined(value) && value.trim() !== '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,13 +2246,12 @@
   dependencies:
     "@babel/runtime" "^7.7.7"
 
-"@togglecorp/toggle-ui@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.9.0.tgz#463175eeb568ea11c0eb6bcbe30fa20a84f5a0c1"
-  integrity sha512-aFEVvBWHKuPLr0hlGg3+4P4kE8J4dEZeV+OUgVk72f2tZsvx6+hkNwpCJlT5anED5MgW6nIN8VcWSm+F+MRACQ==
+"@togglecorp/toggle-ui@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.10.1.tgz#404e3a858f36b10bbb9a560028cd0fdde7e1af95"
+  integrity sha512-pZUGb8BROOmrRx97ZEDR6ZHIWhXKSEnwq2xpobTGb9KviCdHB7WUAHn3RfCbkv1b+JjvLLN2/FkO+MODqgtyOg==
   dependencies:
     "@babel/runtime-corejs3" "^7.11.2"
-    "@storybook/client-api" "^6.0.21"
     "@togglecorp/fujs" "^1.9.2-beta.0"
     d3-axis "^2.0.0"
     d3-scale "^3.2.3"


### PR DESCRIPTION
Related to https://github.com/toggle-corp/toggle-form/issues/14
Related to https://github.com/toggle-corp/toggle-form/issues/13
Related to https://github.com/toggle-corp/toggle-form/issues/12

## Changes

- Add documentation
- Errors for array and object can also be LeafError
- Remove nesting of members and fields in error object
- Rename `$internal` to use symbol
- Update toggle ui
- Introduce forceNullType, forceEmptyArrayType, defaultUndefinedType,
  defaultEmptyArrayType


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
